### PR TITLE
Build before deploying.

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -16,6 +16,9 @@ jobs:
       run: npm install
 
     - name: build
+      run: npm run build
+
+    - name: predeploy
       run: npm run predeploy
 
     - name: deploy


### PR DESCRIPTION
This ensures the build occurs prior to deploying. Previously it was
failing because `dist_varnish` didn't exist.