### PR TITLE
Fix the deploy by removing the SSR flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "pretty-quick": "pretty-quick",
     "pub": "npm run version && antd-tools run pub",
     "prepublishOnly": "antd-tools run guard",
-    "site": "cross-env NODE_ICU_DATA=node_modules/full-icu concurrently \"bisheng build --ssr -c ./site/bisheng.config.js\" \"npm run color-less\"",
+    "site": "cross-env NODE_ICU_DATA=node_modules/full-icu concurrently \"bisheng build -c ./site/bisheng.config.js\" \"npm run color-less\"",
     "sort": "npx sort-package-json",
     "sort-api": "antd-tools run sort-api-table",
     "start": "antd-tools run clean && cross-env NODE_ENV=development concurrently \"npm run color-less\" \"bisheng start -c ./site/bisheng.config.js\"",


### PR DESCRIPTION
This removes the `--ssr` flag, which for some reason causes the static site build to fail.

I'm fairly certain it's because of `site/theme/template/Layout/Header/DemoHeader.tsx`, which is our addition. There's probably something we have to do to make it SSR compatible. I tried a few things, none of which worked.

That said we're not worried about getting eyeballs on our fork as it's an internal tool, so it seems fine to just disable SSR and call this good.

After merging this I should be able to get the site deploying via Github pages (what they use by default). This might be totally ok for our site (we may not need to use Skiff for this).