### PR TITLE
Product `dist_varnish` before trying to deploy the site.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "predist": "npm run version",
     "presite": "npm run version",
     "color-less": "node ./scripts/generate-color-less",
-    "compile": "yarn shellac-build && antd-tools run compile",
+    "compile": "npm run shellac-build && antd-tools run compile",
     "changelog": "node ./scripts/print-changelog",
-    "predeploy": "antd-tools run clean && npm run site",
+    "predeploy": "antd-tools run clean && npm run compile && npm run site",
     "deploy": "bisheng gh-pages --push-only --dotfiles",
     "dist": "antd-tools run dist",
     "lint": "npm run lint:tsc && npm run lint:script && npm run lint:demo && npm run lint:style && npm run lint:deps && npm run lint:md",
@@ -90,7 +90,7 @@
     "tsc": "tsc",
     "site:test": "jest --config .jest.site.js --cache=false",
     "version": "node ./scripts/generate-version",
-    "shellac-build": "yarn tsc --project shellac/tsconfig.json && node shellac/build.js && yarn shellac-optimize",
+    "shellac-build": "npm run tsc -- --project shellac/tsconfig.json && node shellac/build.js && npm run shellac-optimize",
     "shellac-optimize": "postcss dist_varnish/shellac.css > dist_varnish/shellac.min.css"
   },
   "husky": {


### PR DESCRIPTION
The files are required. Without it the build step spins indefinitely.
Here's a link to the failing build: https://github.com/allenai/ant-design/runs/679756690?check_suite_focus=true.  I had to cancel it to see that output, otherwise
it just spins indefinitely on that step.

I also switched the `yarn` usage to `npm`. It seems weird to mix the
two.
