### PR TITLE
Use the github token instead.

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -20,9 +20,9 @@ jobs:
     - name: deploy
       uses: peaceiris/actions-gh-pages@v2
       env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        # ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         # PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: ./_site
       with:


### PR DESCRIPTION
I generated a deploy key, which should fix things, but would prefer
to use the `GITHUB_TOKEN`, as it's a temporary token that's provisioned
for us by Github. See:
https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token

That said there's a bit there about permissions, and how forks only
have read. This makes me worry that it may not work. That said there's
no way for me to try this locally, so let's give this a shot. If it
works I can remove the custom SSH key I generated. If it doesn't
we'll revert this and stick with the SSH key.
